### PR TITLE
feat: replace pagination buttons with infinite scroll on Home and Sea…

### DIFF
--- a/src/Pages/Home.jsx
+++ b/src/Pages/Home.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { YT_API_BASE, YT_API_KEY } from "../constants/api";
 import ShimmerCard from "../Components/ShimmerCard";
@@ -6,40 +6,84 @@ import ShimmerCard from "../Components/ShimmerCard";
 function Home() {
   const [videos, setVideos] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [nextPageToken, setNextPageToken] = useState("");
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [nextPageToken, setNextPageToken] = useState(null);
+  const [hasMore, setHasMore] = useState(true);
 
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 
   const query = searchParams.get("query") || "music";
-  const pageToken = searchParams.get("pageToken") || "";
 
-  useEffect(() => {
-    let ignore = false;
-    setLoading(true);
+  // Sentinel div ref — IntersectionObserver watches this
+  const sentinelRef = useRef(null);
+  // Track current query to reset on query change
+  const currentQueryRef = useRef(query);
 
-    async function fetchVideos() {
-      try {
-        const res = await fetch(
-          `${YT_API_BASE}/search?part=snippet&type=video&maxResults=12&q=${encodeURIComponent(query)}&pageToken=${pageToken}&key=${YT_API_KEY}`
-        );
-        const data = await res.json();
-
-        if (!ignore) {
-          setVideos(data.items || []);
-          setNextPageToken(data.nextPageToken || "");
-        }
-      } catch (error) {
-        console.error("Error fetching videos:", error);
-      } finally {
-        if (!ignore) setLoading(false);
-      }
+  // ── Fetch a page of videos ──────────────────────────────────────────
+  const fetchVideos = useCallback(async (pageToken = "", reset = false) => {
+    if (reset) {
+      setLoading(true);
+    } else {
+      setLoadingMore(true);
     }
 
-    fetchVideos();
-    return () => { ignore = true; };
-  }, [query, pageToken]);
+    try {
+      const res = await fetch(
+        `${YT_API_BASE}/search?part=snippet&type=video&maxResults=12` +
+        `&q=${encodeURIComponent(query)}&pageToken=${pageToken}&key=${YT_API_KEY}`
+      );
+      const data = await res.json();
 
+      const newVideos = data.items || [];
+      const token = data.nextPageToken || null;
+
+      setVideos(prev => reset ? newVideos : [...prev, ...newVideos]);
+      setNextPageToken(token);
+      setHasMore(!!token);
+    } catch (error) {
+      console.error("Error fetching videos:", error);
+      setHasMore(false);
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }, [query]);
+
+  // ── Reset when query changes ────────────────────────────────────────
+  useEffect(() => {
+    currentQueryRef.current = query;
+    setVideos([]);
+    setNextPageToken(null);
+    setHasMore(true);
+    fetchVideos("", true);
+  }, [query]);
+
+  // ── IntersectionObserver — fires when sentinel enters viewport ──────
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        // Only load more if: sentinel is visible + not already loading + more pages exist
+        if (entry.isIntersecting && hasMore && !loadingMore && !loading) {
+          fetchVideos(nextPageToken || "");
+        }
+      },
+      {
+        root: null,       // viewport
+        rootMargin: "200px", // start loading 200px before sentinel is visible
+        threshold: 0,
+      }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, loadingMore, loading, nextPageToken, fetchVideos]);
+
+  // ── Navigate to Watch page ──────────────────────────────────────────
   const handleVideoClick = (video) => {
     navigate("/watch", {
       state: {
@@ -52,16 +96,10 @@ function Home() {
     });
   };
 
-  const handleNext = () => {
-    if (nextPageToken) setSearchParams({ query, pageToken: nextPageToken });
-  };
-
-  const handlePrev = () => {
-    setSearchParams({ query, pageToken: "" });
-  };
-
   return (
     <div className="p-4 min-h-screen">
+
+      {/* Initial load shimmer */}
       {loading ? (
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
           {Array.from({ length: 12 }).map((_, i) => (
@@ -70,10 +108,11 @@ function Home() {
         </div>
       ) : (
         <>
+          {/* Video grid — new videos append here */}
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-            {videos.map((video) => (
+            {videos.map((video, index) => (
               <div
-                key={video.id.videoId}
+                key={`${video.id.videoId}-${index}`}
                 className="cursor-pointer group"
                 onClick={() => handleVideoClick(video)}
               >
@@ -109,24 +148,25 @@ function Home() {
             ))}
           </div>
 
-          <div className="mt-8 flex justify-center gap-4">
-            {pageToken && (
-              <button
-                onClick={handlePrev}
-                className="px-5 py-2 bg-zinc-700 text-white rounded-lg hover:bg-zinc-600 transition font-medium"
-              >
-                ← Previous
-              </button>
-            )}
-            {nextPageToken && (
-              <button
-                onClick={handleNext}
-                className="px-5 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition font-medium"
-              >
-                Next →
-              </button>
-            )}
-          </div>
+          {/* Loading more spinner — shows between pages */}
+          {loadingMore && (
+            <div className="flex justify-center items-center py-10 gap-3">
+              <div className="w-6 h-6 border-2 border-zinc-600 border-t-red-500 rounded-full animate-spin" />
+              <span className="text-gray-400 text-sm">Loading more videos...</span>
+            </div>
+          )}
+
+          {/* End of results message */}
+          {!hasMore && !loadingMore && videos.length > 0 && (
+            <div className="flex flex-col items-center py-10 gap-2">
+              <div className="w-10 h-px bg-zinc-700" />
+              <p className="text-gray-500 text-sm">You've reached the end</p>
+              <div className="w-10 h-px bg-zinc-700" />
+            </div>
+          )}
+
+          {/* Sentinel — IntersectionObserver watches this invisible div */}
+          <div ref={sentinelRef} className="h-1 w-full" />
         </>
       )}
     </div>

--- a/src/Pages/Search.jsx
+++ b/src/Pages/Search.jsx
@@ -1,97 +1,149 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
 import { fetchSearchResults } from "../api/search";
 import SearchShimmer from "../Components/Shimmer/SearchShimmer";
 import TrendingCard from "../Components/Trending/TrendingCard";
 
 function Search() {
-  const [searchParams, setSearchParams] = useSearchParams();
-
+  const [searchParams] = useSearchParams();
   const query = searchParams.get("q");
-  const pageToken = searchParams.get("pageToken") || ""; // ✅ token-based pagination
 
   const [videos, setVideos] = useState([]);
-  const [nextPageToken, setNextPageToken] = useState(null);
-  const [prevPageToken, setPrevPageToken] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [nextPageToken, setNextPageToken] = useState(null);
+  const [hasMore, setHasMore] = useState(true);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
+  const sentinelRef = useRef(null);
+
+  // ── Fetch a page of search results ─────────────────────────────────
+  const fetchMore = useCallback(async (pageToken = "", reset = false) => {
     if (!query) return;
-    let ignore = false;
 
-    async function loadSearch() {
-      setLoading(true);
-      setError(null);
+    if (reset) setLoading(true);
+    else setLoadingMore(true);
 
-      try {
-        // ✅ fetchSearchResults now returns { videos, nextPageToken, prevPageToken }
-        const result = await fetchSearchResults(query, pageToken);
+    setError(null);
 
-        if (!ignore) {
-          setVideos(result.videos);
-          setNextPageToken(result.nextPageToken);
-          setPrevPageToken(result.prevPageToken);
-        }
-      } catch {
-        if (!ignore) setError("Failed to load search results");
-      } finally {
-        if (!ignore) setLoading(false);
-      }
+    try {
+      const result = await fetchSearchResults(query, pageToken);
+
+      setVideos(prev => reset ? result.videos : [...prev, ...result.videos]);
+      setNextPageToken(result.nextPageToken);
+      setHasMore(!!result.nextPageToken);
+    } catch {
+      setError("Failed to load search results");
+      setHasMore(false);
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
     }
+  }, [query]);
 
-    loadSearch();
-    return () => { ignore = true; };
-  }, [query, pageToken]);
+  // ── Reset when query changes ────────────────────────────────────────
+  useEffect(() => {
+    setVideos([]);
+    setNextPageToken(null);
+    setHasMore(true);
+    setError(null);
+    fetchMore("", true);
+  }, [query]);
 
-  const goNext = () => {
-    if (nextPageToken) setSearchParams({ q: query, pageToken: nextPageToken });
-  };
+  // ── IntersectionObserver ────────────────────────────────────────────
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
 
-  const goPrev = () => {
-    if (prevPageToken) setSearchParams({ q: query, pageToken: prevPageToken });
-    else setSearchParams({ q: query });
-  };
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry.isIntersecting && hasMore && !loadingMore && !loading) {
+          fetchMore(nextPageToken || "");
+        }
+      },
+      {
+        root: null,
+        rootMargin: "200px",
+        threshold: 0,
+      }
+    );
 
-  if (!query) return <div className="p-4 text-white">Enter a search term above</div>;
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, loadingMore, loading, nextPageToken, fetchMore]);
+
+  if (!query) {
+    return (
+      <div className="p-8 text-center text-gray-400">
+        <p className="text-xl">🔍 Enter a search term above</p>
+      </div>
+    );
+  }
+
   if (loading) return <SearchShimmer />;
-  if (error) return <div className="p-4 text-red-500 font-semibold">{error}</div>;
+
+  if (error) {
+    return (
+      <div className="p-8 flex flex-col items-center justify-center min-h-[60vh]">
+        <div className="bg-zinc-900 border border-red-800 rounded-xl p-8 text-center max-w-md">
+          <p className="text-red-400 text-4xl mb-4">⚠️</p>
+          <h2 className="text-white font-bold text-lg mb-2">Something went wrong</h2>
+          <p className="text-gray-400 text-sm">{error}</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="p-4">
+      {/* Header */}
       <h2 className="mb-6 text-xl font-semibold text-white">
-        Results for <span className="text-blue-400">"{query}"</span>
+        Results for{" "}
+        <span className="text-red-400">"{query}"</span>
+        <span className="text-gray-400 text-sm font-normal ml-3">
+          {videos.length} videos loaded
+        </span>
       </h2>
 
-      {videos.length === 0 ? (
-        <div className="text-gray-400 text-center mt-12">No results found.</div>
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-          {videos.map((video) => (
-            <TrendingCard key={video.video_id} video={video} />
-          ))}
+      {videos.length === 0 && !loadingMore ? (
+        <div className="text-center mt-12">
+          <p className="text-gray-400 text-xl">No results found.</p>
+          <p className="text-gray-500 text-sm mt-2">Try a different search term.</p>
         </div>
-      )}
+      ) : (
+        <>
+          {/* Results grid — appends as user scrolls */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+            {videos.map((video, index) => (
+              <TrendingCard
+                key={`${video.video_id}-${index}`}
+                video={video}
+              />
+            ))}
+          </div>
 
-      {/* ✅ Token-based pagination — works correctly with YouTube v3 */}
-      <div className="flex justify-center gap-4 mt-8">
-        {prevPageToken && (
-          <button
-            onClick={goPrev}
-            className="px-4 py-2 bg-zinc-700 rounded text-white hover:bg-zinc-600 transition"
-          >
-            ← Previous
-          </button>
-        )}
-        {nextPageToken && (
-          <button
-            onClick={goNext}
-            className="px-4 py-2 bg-zinc-700 rounded text-white hover:bg-zinc-600 transition"
-          >
-            Next →
-          </button>
-        )}
-      </div>
+          {/* Loading more spinner */}
+          {loadingMore && (
+            <div className="flex justify-center items-center py-10 gap-3">
+              <div className="w-6 h-6 border-2 border-zinc-600 border-t-red-500 rounded-full animate-spin" />
+              <span className="text-gray-400 text-sm">Loading more results...</span>
+            </div>
+          )}
+
+          {/* End of results */}
+          {!hasMore && !loadingMore && videos.length > 0 && (
+            <div className="flex flex-col items-center py-10 gap-2">
+              <div className="w-10 h-px bg-zinc-700" />
+              <p className="text-gray-500 text-sm">You've reached the end</p>
+              <div className="w-10 h-px bg-zinc-700" />
+            </div>
+          )}
+
+          {/* Sentinel */}
+          <div ref={sentinelRef} className="h-1 w-full" />
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
**Title:**
```
feat: replace pagination buttons with infinite scroll on Home and Search pages
```

**Description:**
```
## What this PR does
- Removed Previous / Next pagination buttons from Home and Search pages
- Added IntersectionObserver watching a sentinel div at the bottom of each grid
- New videos append to the grid instead of replacing — scroll position preserved
- Spinner with "Loading more videos..." text shows between page fetches
- "You've reached the end" message appears when no more pages exist
- Fires 200px before sentinel is visible so load feels seamless
- Query changes (new search term) correctly reset the video list and restart

## How IntersectionObserver works here
A tiny invisible `<div ref={sentinelRef}>` sits below the video grid.
The observer fires whenever that div enters the viewport. On fire it calls 
fetchMore() with the current nextPageToken, appending new results to state.
